### PR TITLE
fix: remove erasing word info

### DIFF
--- a/src/components/Textbook/textbookState.ts
+++ b/src/components/Textbook/textbookState.ts
@@ -6,6 +6,7 @@ interface ITextbookState {
 
   addLearnedWord: () => void;
   deleteLearnedWord: () => void;
+  setLearnedWords: (card: HTMLDivElement) => void;
 }
 
 const textbookState: ITextbookState = {
@@ -30,6 +31,11 @@ const textbookState: ITextbookState = {
       gameControls.querySelectorAll('button').forEach((btn) => btn.removeAttribute('disabled'));
       gameControls.classList.remove('disabled');
     }
+  },
+
+  setLearnedWords(card) {
+    if (card.classList.contains('learned')) this.addLearnedWord();
+    else this.deleteLearnedWord();
   },
 };
 


### PR DESCRIPTION
Now when user clicks "hard" / "learned" button - userWord properties are being updated, but not created from scratch (if the word is in the datebase, else new userWord is being created).